### PR TITLE
fix Apache Parquet C++ link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ package.
 ## Apache Parquet C++
 
 This section describes how to install
-[Apache Parquet C++](https://github.com/apache/parquet) package.
+[Apache Parquet C++](https://github.com/apache/parquet-cpp) package.
 
 ### Debian GNU/Linux
 


### PR DESCRIPTION
change the link https://github.com/apache/parquet to https://github.com/apache/parquet-cpp