### PR TITLE
Remove `$` mark from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,16 @@ Run the following command lines to add apt-lines for APT repository on
 packages.red-data-tools.org:
 
 ```console
-$ sudo apt install -y -V ca-certificates lsb-release wget
-$ wget https://packages.red-data-tools.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/red-data-tools-apt-source-latest-$(lsb_release --codename --short).deb
-$ sudo apt install -y -V ./red-data-tools-apt-source-latest-$(lsb_release --codename --short).deb
-$ sudo apt update
+sudo apt install -y -V ca-certificates lsb-release wget
+wget https://packages.red-data-tools.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/red-data-tools-apt-source-latest-$(lsb_release --codename --short).deb
+sudo apt install -y -V ./red-data-tools-apt-source-latest-$(lsb_release --codename --short).deb
+sudo apt update
 ```
 
 ### CentOS
 
 ```console
-$ (. /etc/os-release && sudo dnf install -y https://packages.red-data-tools.org/centos/${VERSION_ID}/red-data-tools-release-latest.noarch.rpm)
+(. /etc/os-release && sudo dnf install -y https://packages.red-data-tools.org/centos/${VERSION_ID}/red-data-tools-release-latest.noarch.rpm)
 ```
 
 ## How to install packages
@@ -48,17 +48,17 @@ $ (. /etc/os-release && sudo dnf install -y https://packages.red-data-tools.org/
 ### OpenCV GLib
 
 ```console
-$ sudo apt install libopencv-glib-dev
+sudo apt install libopencv-glib-dev
 ```
 
 ### GR framework
 
 ```console
-$ sudo apt install libgrm-dev
+sudo apt install libgrm-dev
 ```
 
 ```console
-$ sudo dnf install gr-devel
+sudo dnf install gr-devel
 ```
 
 ## Development
@@ -66,8 +66,8 @@ $ sudo dnf install gr-devel
 ### How to deploy
 
 ```console
-$ sudo apt install ansible
-$ rake deploy
+sudo apt install ansible
+rake deploy
 ```
 
 ### How to create packages
@@ -75,15 +75,15 @@ $ rake deploy
 Here are command lines to build .deb files and update APT repository:
 
 ```console
-$ git submodule update --init
-$ rake apt
+git submodule update --init
+rake apt
 ```
 
 Here are command lines to build .rpm files and update Yum repository:
 
 ```console
-$ git submodule update --init
-$ rake yum
+git submodule update --init
+rake yum
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ enable the package repository before you install packages.
 Run the following command lines to add apt-lines for APT repository on
 packages.red-data-tools.org:
 
-```console
+```bash
 sudo apt install -y -V ca-certificates lsb-release wget
 wget https://packages.red-data-tools.org/$(lsb_release --id --short | tr 'A-Z' 'a-z')/red-data-tools-apt-source-latest-$(lsb_release --codename --short).deb
 sudo apt install -y -V ./red-data-tools-apt-source-latest-$(lsb_release --codename --short).deb
@@ -39,7 +39,7 @@ sudo apt update
 
 ### CentOS
 
-```console
+```bash
 (. /etc/os-release && sudo dnf install -y https://packages.red-data-tools.org/centos/${VERSION_ID}/red-data-tools-release-latest.noarch.rpm)
 ```
 
@@ -47,17 +47,17 @@ sudo apt update
 
 ### OpenCV GLib
 
-```console
+```bash
 sudo apt install libopencv-glib-dev
 ```
 
 ### GR framework
 
-```console
+```bash
 sudo apt install libgrm-dev
 ```
 
-```console
+```bash
 sudo dnf install gr-devel
 ```
 
@@ -65,7 +65,7 @@ sudo dnf install gr-devel
 
 ### How to deploy
 
-```console
+```bash
 sudo apt install ansible
 rake deploy
 ```
@@ -74,14 +74,14 @@ rake deploy
 
 Here are command lines to build .deb files and update APT repository:
 
-```console
+```bash
 git submodule update --init
 rake apt
 ```
 
 Here are command lines to build .rpm files and update Yum repository:
 
-```console
+```bash
 git submodule update --init
 rake yum
 ```


### PR DESCRIPTION
https://github.com/red-data-tools/packages.red-data-tools.org/pull/16#discussion_r602836738
> Why do you want to remove those options?
> If we have them, users can install by copy & paste.

> By the way, if your priority is to be able to copy and paste, I think we should remove the `$` at the beginning of the line.

This pull request is to remove `$` symbols and make it easier to copy and paste.
My motivation is to make the installation of GR as easy as possible for those who use GR.rb or GR.cr.

`$` symbol has several advantages.
* It makes it clear that you are running in a terminal
* Good readability when viewing Markdown in plain text

However, in the Github README, the majority of project do not use `$`, probably because of the convenience of copy and paste.
I thought it would be somewhat better to remove `$`. What do you think?
