### PR TITLE
Add missing debug symbol packages for APT packages

### DIFF
--- a/repository-task.rb
+++ b/repository-task.rb
@@ -692,7 +692,7 @@ Dir::ArchiveDir ".";
 Dir::CacheDir ".";
 TreeDefault::Directory "pool/#{code_name}/#{component}";
 TreeDefault::SrcDirectory "pool/#{code_name}/#{component}";
-Default::Packages::Extensions ".deb";
+Default::Packages::Extensions ".deb .ddeb";
 Default::Packages::Compress ". gzip xz";
 Default::Sources::Compress ". gzip xz";
 Default::Contents::Compress "gzip";


### PR DESCRIPTION
Fix: pgroonga/pgroonga#382

We build PGroonga's packages for Ubuntu and Debian by using this script. However, this script missing definition for including debug symbol packages. So, https://packages.groonga.org/ubuntu/dists/jammy/universe/binary-amd64/Packages doesn't include postgresql-14-pgdg-pgroonga-dbgsym.

We can include debug symbol packages in the packages for Ubuntu and Debian by this modification. Here is the result of "rake apt:build" command with this modification.

```
├── apt
│   ├── build.sh
│   ├── debian-bookworm
│   │   └── Dockerfile
│   ├── debian-bookworm-arm64
│   │   └── from
│   ├── debian-bullseye
│   │   └── Dockerfile
│   ├── debian-bullseye-arm64
│   │   └── from
│   ├── env.sh
│   ├── repositories
│   │   ├── debian
│   │   │   └── pool
│   │   │       ├── bookworm
│   │   │       │   └── main
│   │   │       │       └── p
│   │   │       │           └── postgresql-14-pgdg-pgroonga
│   │   │       │               ├── postgresql-14-pgdg-pgroonga-dbgsym_3.1.6-1_amd64.deb
│   │   │       │               ├── postgresql-14-pgdg-pgroonga_3.1.6-1.debian.tar.xz
│   │   │       │               ├── postgresql-14-pgdg-pgroonga_3.1.6-1.dsc
│   │   │       │               ├── postgresql-14-pgdg-pgroonga_3.1.6-1_amd64.buildinfo
│   │   │       │               ├── postgresql-14-pgdg-pgroonga_3.1.6-1_amd64.changes
│   │   │       │               ├── postgresql-14-pgdg-pgroonga_3.1.6-1_amd64.deb
│   │   │       │               └── postgresql-14-pgdg-pgroonga_3.1.6.orig.tar.gz
│   │   │       └── bullseye
│   │   │           └── main
│   │   │               └── p
│   │   │                   └── postgresql-14-pgdg-pgroonga
│   │   │                       ├── postgresql-14-pgdg-pgroonga-dbgsym_3.1.6-1_amd64.deb
│   │   │                       ├── postgresql-14-pgdg-pgroonga_3.1.6-1.debian.tar.xz
│   │   │                       ├── postgresql-14-pgdg-pgroonga_3.1.6-1.dsc
│   │   │                       ├── postgresql-14-pgdg-pgroonga_3.1.6-1_amd64.buildinfo
│   │   │                       ├── postgresql-14-pgdg-pgroonga_3.1.6-1_amd64.changes
│   │   │                       ├── postgresql-14-pgdg-pgroonga_3.1.6-1_amd64.deb
│   │   │                       └── postgresql-14-pgdg-pgroonga_3.1.6.orig.tar.gz
│   │   └── ubuntu
│   │       └── pool
│   │           ├── focal
│   │           │   └── universe
│   │           │       └── p
│   │           │           └── postgresql-14-pgdg-pgroonga
│   │           │               ├── postgresql-14-pgdg-pgroonga-dbgsym_3.1.6-1_amd64.ddeb
│   │           │               ├── postgresql-14-pgdg-pgroonga_3.1.6-1.debian.tar.xz
│   │           │               ├── postgresql-14-pgdg-pgroonga_3.1.6-1.dsc
│   │           │               ├── postgresql-14-pgdg-pgroonga_3.1.6-1_amd64.buildinfo
│   │           │               ├── postgresql-14-pgdg-pgroonga_3.1.6-1_amd64.changes
│   │           │               ├── postgresql-14-pgdg-pgroonga_3.1.6-1_amd64.deb
│   │           │               └── postgresql-14-pgdg-pgroonga_3.1.6.orig.tar.gz
│   │           └── jammy
│   │               └── universe
│   │                   └── p
│   │                       └── postgresql-14-pgdg-pgroonga
│   │                           ├── postgresql-14-pgdg-pgroonga-dbgsym_3.1.6-1_amd64.ddeb
│   │                           ├── postgresql-14-pgdg-pgroonga_3.1.6-1.debian.tar.xz
│   │                           ├── postgresql-14-pgdg-pgroonga_3.1.6-1.dsc
│   │                           ├── postgresql-14-pgdg-pgroonga_3.1.6-1_amd64.buildinfo
│   │                           ├── postgresql-14-pgdg-pgroonga_3.1.6-1_amd64.changes
│   │                           ├── postgresql-14-pgdg-pgroonga_3.1.6-1_amd64.deb
│   │                           └── postgresql-14-pgdg-pgroonga_3.1.6.orig.tar.gz
```